### PR TITLE
Fix - Call to a member function hasRole() on null - in \app\Http\Middleware\RoleMiddleware.php

### DIFF
--- a/app/Http/Middleware/RoleMiddleware.php
+++ b/app/Http/Middleware/RoleMiddleware.php
@@ -18,12 +18,21 @@ class RoleMiddleware
 	 */
     public function handle($request, Closure $next, $role, $permission = null)
     {
+	/**
+	 * Fix for "Call to a member function hasRole() on null".
+	 * If the user is not logged in, there is no user data to process,
+	 * so we need to throw 404 code.
+	 */
+	if(is_null($request->user())){
+            abort(404);
+        }
+	    
     	if(!$request->user()->hasRole($role)) {
 			abort(404);
 	    }
-	    if($permission !== null && !$request->user()->can($permission)) {
-    		abort(404);
-	    }
+	if($permission !== null && !$request->user()->can($permission)) {
+		abort(404);
+	}
         return $next($request);
     }
 }


### PR DESCRIPTION
Fix for `Call to a member function hasRole() on null` error. If the user is not logged in, there is no user data to process, so we need to throw 404 code.

Full error message:
```
Symfony \ Component \ Debug \ Exception \ FatalThrowableError (E_ERROR)
Call to a member function hasRole() on null
…\app\Http\Middleware\RoleMiddleware.php
Line 21
```
